### PR TITLE
remove calling systemd-sleep-grub

### DIFF
--- a/units/systemd-hibernate.service.in
+++ b/units/systemd-hibernate.service.in
@@ -15,6 +15,5 @@ ConditionKernelCommandLine=resume
 
 [Service]
 Type=oneshot
-ExecStart=@rootbindir@/systemd-sleep-grub pre
 ExecStart=@rootlibexecdir@/systemd-sleep hibernate
 ExecStopPost=@rootbindir@/systemd-sleep-grub post

--- a/units/systemd-hibernate.service.in
+++ b/units/systemd-hibernate.service.in
@@ -16,4 +16,3 @@ ConditionKernelCommandLine=resume
 [Service]
 Type=oneshot
 ExecStart=@rootlibexecdir@/systemd-sleep hibernate
-ExecStopPost=@rootbindir@/systemd-sleep-grub post

--- a/units/systemd-hybrid-sleep.service.in
+++ b/units/systemd-hybrid-sleep.service.in
@@ -15,6 +15,5 @@ ConditionKernelCommandLine=resume
 
 [Service]
 Type=oneshot
-ExecStart=@rootbindir@/systemd-sleep-grub pre
 ExecStart=@rootlibexecdir@/systemd-sleep hybrid-sleep
 ExecStopPost=@rootbindir@/systemd-sleep-grub post

--- a/units/systemd-hybrid-sleep.service.in
+++ b/units/systemd-hybrid-sleep.service.in
@@ -16,4 +16,3 @@ ConditionKernelCommandLine=resume
 [Service]
 Type=oneshot
 ExecStart=@rootlibexecdir@/systemd-sleep hybrid-sleep
-ExecStopPost=@rootbindir@/systemd-sleep-grub post


### PR DESCRIPTION
This is now in contained in a grub2 plugin and is not needed anymore.
See boo#941758 or boo#991350