### PR TITLE
Fix parsing of features in detect_vm_xen_dom0

### DIFF
--- a/src/basic/virt.c
+++ b/src/basic/virt.c
@@ -239,8 +239,8 @@ static bool detect_vm_xen_dom0(void) {
         if (r == 0) {
                 unsigned long features;
 
-                r = safe_atolu(domcap, &features);
-                if (r == 0) {
+                r = sscanf(domcap, "%lx", &features);
+                if (r == 1) {
                         r = !!(features & (1U << XENFEAT_dom0));
                         log_debug("Virtualization XEN, found %s with value %08lx, "
                                   "XENFEAT_dom0 (indicating the 'hardware domain') is%s set.",


### PR DESCRIPTION
Use sscanf instead of the built-in safe_atolu because the scanned string
lacks the leading "0x", it is generated with snprintf(b, "%08x", val).
As a result strtoull handles it as octal, and parsing fails.

The initial submission already used sscanf, then parsing was replaced by
safe_atolu without retesting the updated PR.

Fixes 575e6588d ("virt: use XENFEAT_dom0 to detect the hardware domain
(#6442, #6662) (#7581)")
[ohering: fixes bsc#1048510]