### PR TITLE
systemd-udevd: limit children-max by available memory

### DIFF
--- a/src/udev/udevd.c
+++ b/src/udev/udevd.c
@@ -1677,11 +1677,15 @@ int main(int argc, char *argv[]) {
 
         if (arg_children_max == 0) {
                 cpu_set_t cpu_set;
+                unsigned long mem_limit;
 
                 arg_children_max = 8;
 
                 if (sched_getaffinity(0, sizeof(cpu_set), &cpu_set) == 0)
                         arg_children_max += CPU_COUNT(&cpu_set) * 64;
+
+                mem_limit = physical_memory() / (128LU*1024*1024);
+                arg_children_max = MAX(10U, MIN(arg_children_max, mem_limit));
 
                 log_debug("set children_max to %u", arg_children_max);
         }


### PR DESCRIPTION
Udev workers consume typically 50-100MiB virtual memory.
On systems with lots of CPUs and relatively low memory, that may
easily cause workers to be OOM-killed.

This patch limits the number of workers to 8 per GiB memory.
But don't let the limit drop below the smallest value we had
without this patch (8 + 1 * 2 = 10); on small systems, udev's
memory footprint is likely lower.

Suggested fix for bsc#1086785. Submitting here fore review.