### PR TITLE
Fix regexp to detect distribution

### DIFF
--- a/test/test-functions
+++ b/test/test-functions
@@ -6,7 +6,7 @@ export PATH
 
 LOOKS_LIKE_DEBIAN=$(source /etc/os-release && [[ "$ID" = "debian" || "$ID_LIKE" = "debian" ]] && echo yes)
 LOOKS_LIKE_ARCH=$(source /etc/os-release && [[ "$ID" = "arch" ]] && echo yes)
-LOOKS_LIKE_SUSE=$(source /etc/os-release && [[ "$ID_LIKE" = "suse" ]] && echo yes)
+LOOKS_LIKE_SUSE=$(source /etc/os-release && [[ "$ID_LIKE" =~ "suse" ]] && echo yes)
 KERNEL_VER=${KERNEL_VER-$(uname -r)}
 KERNEL_MODS="/lib/modules/$KERNEL_VER/"
 QEMU_TIMEOUT="${QEMU_TIMEOUT:-infinity}"


### PR DESCRIPTION
To fix recent missing initrd parameter on openSUSE: https://openqa.opensuse.org/tests/678673#step/systemd_testsuite/49

- Related ticket: https://progress.opensuse.org/issues/34996
- Verification run: (coming soon)