### PR TITLE
udev/cdrom_id: Do not open CD-rom in exclusive mode.

### DIFF
--- a/src/udev/cdrom_id/cdrom_id.c
+++ b/src/udev/cdrom_id/cdrom_id.c
@@ -85,28 +85,6 @@ static unsigned long long int cd_media_session_last_offset;
 #define ASC(errcode)        (((errcode) >> 8) & 0xFF)
 #define ASCQ(errcode)        ((errcode) & 0xFF)
 
-static bool is_mounted(const char *device) {
-        struct stat statbuf;
-        FILE *fp;
-        int maj, min;
-        bool mounted = false;
-
-        if (stat(device, &statbuf) < 0)
-                return false;
-
-        fp = fopen("/proc/self/mountinfo", "re");
-        if (!fp)
-                return false;
-        while (fscanf(fp, "%*s %*s %i:%i %*[^\n]", &maj, &min) == 2) {
-                if (makedev(maj, min) == statbuf.st_rdev) {
-                        mounted = true;
-                        break;
-                }
-        }
-        fclose(fp);
-        return mounted;
-}
-
 static void info_scsi_cmd_err(const char *cmd, int err) {
         if (err == -1)
                 log_debug("%s failed", cmd);
@@ -873,7 +851,7 @@ int main(int argc, char *argv[]) {
         for (cnt = 20; cnt > 0; cnt--) {
                 struct timespec duration;
 
-                fd = open(node, O_RDONLY|O_NONBLOCK|O_CLOEXEC|(is_mounted(node) ? 0 : O_EXCL));
+                fd = open(node, O_RDONLY|O_NONBLOCK|O_CLOEXEC);
                 if (fd >= 0 || errno != EBUSY)
                         break;
                 duration.tv_sec = 0;


### PR DESCRIPTION
When you have a CD automunt solution that talks directly to the kernel
independently of udev it races with cdrom_id for exclusive access to the
device failing unpredictably.

The whole is_mounted function in cdrom_id is broken: there is no saying
what happens between calling is_mounted and opening the device.

Hence assume that the device can be mounted asynchronously at any time,
do not use exclusive access, and do away with is_mouted.

Signed-off-by: Michal Suchanek <msuchanek@suse.de>