### PR TITLE
systemd-udev-trigger.service: skip coldplug for memory devices

### DIFF
--- a/units/systemd-udev-trigger.service
+++ b/units/systemd-udev-trigger.service
@@ -20,4 +20,4 @@ ConditionPathIsReadWrite=/sys
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=udevadm trigger --type=subsystems --action=add
-ExecStart=udevadm trigger --type=devices --action=add
+ExecStart=udevadm trigger --type=devices --subsystem-nomatch=memory --action=add


### PR DESCRIPTION
udev rules for memory devices are necessary to deal with actual
memory hotplug events. But they aren't necessary for initialization
during early boot. On large systems, in particular on the PowerPC
architecture, coldplug for memory devices may trigger 10000s of
uevents, which may cause system stalls because of scaling
issues in both udev and the kernel.

Therefore, skip uevents for memory devices during coldplug.
SUSE reference: bsc#1174287