### PR TITLE
Fix tests backports

### DIFF
--- a/src/libsystemd-network/test-dhcp-server.c
+++ b/src/libsystemd-network/test-dhcp-server.c
@@ -62,7 +62,9 @@ static int test_basic(bool bind_to_interface) {
         test_pool(&address_lo, 1, 0);
 
         r = sd_dhcp_server_start(server);
-        if (r == -EPERM)
+        /* skip test if running in an environment with no full networking support, CONFIG_PACKET not
+         * compiled in kernel, nor af_packet module available. */
+        if (r == -EPERM || r == -EAFNOSUPPORT)
                 return r;
         assert_se(r >= 0);
 

--- a/src/libsystemd/meson.build
+++ b/src/libsystemd/meson.build
@@ -159,6 +159,10 @@ libsystemd_tests += [
                 'sources' : files('sd-journal/test-journal-enum.c'),
                 'timeout' : 360,
         },
+        {
+                'sources' : files('sd-event/test-event.c'),
+                'timeout' : 120,
+        }
 ]
 
 ############################################################
@@ -171,7 +175,6 @@ simple_tests += files(
         'sd-device/test-device-util.c',
         'sd-device/test-sd-device-monitor.c',
         'sd-device/test-sd-device.c',
-        'sd-event/test-event.c',
         'sd-journal/test-journal-flush.c',
         'sd-journal/test-journal-interleaving.c',
         'sd-journal/test-journal-stream.c',

--- a/test/test-rpm-macros.sh
+++ b/test/test-rpm-macros.sh
@@ -137,7 +137,7 @@ for i in sysusers tmpfiles; do
 
     PKG_DATA_FILE="$(mktemp "$WORK_DIR/pkg-data-XXX")"
     EXP_OUT="$(mktemp "$WORK_DIR/exp-out-XXX.log")"
-    CONF_DIR="$(pkg-config --variable="${i}dir" systemd)"
+    CONF_DIR="$(PKG_CONFIG_PATH="${BUILD_DIR}/src/core" pkg-config --variable="${i}dir" systemd)"
     EXTRA_ARGS=()
 
     if [[ "$i" == tmpfiles ]]; then


### PR DESCRIPTION
Backport some fixes from upstream needed to enable running tests in the build service