### PR TITLE
kmod-setup: load vsock_loopback alongside vsock

### DIFF
--- a/src/core/kmod-setup.c
+++ b/src/core/kmod-setup.c
@@ -94,6 +94,10 @@ static bool in_vmware(void) {
 static bool in_hyperv(void) {
         return detect_vm() == VIRTUALIZATION_MICROSOFT;
 }
+
+static bool may_have_vsock_loopback(void) {
+        return may_have_virtio() || in_vmware();
+}
 #endif
 
 int kmod_setup(void) {
@@ -107,11 +111,11 @@ int kmod_setup(void) {
         } kmod_table[] = {
                 /* This one we need to load explicitly, since auto-loading on use doesn't work
                  * before udev created the ghost device nodes, and we need it earlier than that. */
-                { "autofs4",                    "/sys/class/misc/autofs",    true,  false, NULL               },
+                { "autofs4",                    "/sys/class/misc/autofs",       true,  false, NULL                      },
 
                 /* This one we need to load explicitly, since auto-loading of IPv6 is not done when
                  * we try to configure ::1 on the loopback device. */
-                { "ipv6",                       "/sys/module/ipv6",          false, true,  NULL               },
+                { "ipv6",                       "/sys/module/ipv6",             false, true,  NULL                      },
 
                 /* This should never be a module */
                 { "unix",                       "/proc/net/unix",            true,  true,  NULL               },
@@ -121,16 +125,18 @@ int kmod_setup(void) {
                 { "ip_tables",                  "/proc/net/ip_tables_names", false, false, NULL               },
 #endif
                 /* virtio_rng would be loaded by udev later, but real entropy might be needed very early */
-                { "virtio_rng",                 NULL,                        false, false, has_virtio_rng     },
+                { "virtio_rng",                 NULL,                           false, false, has_virtio_rng            },
 
                 /* we want early logging to hvc consoles if possible, and make sure systemd-getty-generator
                  * can rely on all consoles being probed already. */
-                { "virtio_console",             NULL,                        false, false, may_have_virtio    },
+                { "virtio_console",             NULL,                           false, false, may_have_virtio           },
 
                 /* Make sure we can send sd-notify messages over vsock as early as possible. */
-                { "vmw_vsock_virtio_transport", NULL,                        false, false, may_have_virtio    },
-                { "vmw_vsock_vmci_transport",   NULL,                        false, false, in_vmware          },
-                { "hv_sock",                    NULL,                        false, false, in_hyperv          },
+                { "vmw_vsock_virtio_transport", NULL,                           false, false, may_have_virtio           },
+                /* vsock_loopback provides VMADDR_CID_LOCAL and is not a hard dep of any transport module */
+                { "vsock_loopback",             "/sys/module/vsock_loopback",   false, false, may_have_vsock_loopback   },
+                { "vmw_vsock_vmci_transport",   NULL,                           false, false, in_vmware                 },
+                { "hv_sock",                    NULL,                           false, false, in_hyperv                 },
 
                 /* We can't wait for specific virtiofs tags to show up as device nodes so we have to load the
                  * virtiofs and virtio_pci modules early to make sure the virtiofs tags are found when
@@ -138,18 +144,18 @@ int kmod_setup(void) {
                  *
                  * TODO: Remove these again once https://gitlab.com/virtio-fs/virtiofsd/-/issues/128 is
                  * resolved and the kernel fix is widely available. */
-                { "virtiofs",                   "/sys/module/virtiofs",      false, false, may_have_virtio    },
-                { "virtio_pci",                 "/sys/module/virtio_pci",    false, false, has_virtio_pci     },
+                { "virtiofs",                   "/sys/module/virtiofs",         false, false, may_have_virtio           },
+                { "virtio_pci",                 "/sys/module/virtio_pci",       false, false, has_virtio_pci            },
 
                 /* qemu_fw_cfg would be loaded by udev later, but we want to import credentials from it super early */
-                { "qemu_fw_cfg",                "/sys/firmware/qemu_fw_cfg", false, false, in_qemu            },
+                { "qemu_fw_cfg",                "/sys/firmware/qemu_fw_cfg",    false, false, in_qemu                   },
 
                 /* dmi-sysfs is needed to import credentials from it super early */
-                { "dmi-sysfs",                  "/sys/firmware/dmi/entries", false, false, NULL               },
+                { "dmi-sysfs",                  "/sys/firmware/dmi/entries",    false, false, NULL                      },
 
 #if HAVE_TPM2
                 /* Make sure the tpm subsystem is available which ConditionSecurity=tpm2 depends on. */
-                { "tpm",                        "/sys/class/tpmrm",          false, false, efi_has_tpm2       },
+                { "tpm",                        "/sys/class/tpmrm",             false, false, efi_has_tpm2              },
 #endif
         };
 


### PR DESCRIPTION
Loading vmw_vsock_virtio_transport early at boot causes vsock to be resident before any application opens an AF_VSOCK socket. Because the kernel skips autoloading when the vsock module is already present, vsock_loopback never gets loaded automatically, and any subsequent bind() to VMADDR_CID_LOCAL fails with EADDRNOTAVAIL.

Fix this by explicitly loading vsock_loopback on virtio or VMWare machines via the new may_have_vsock_looopback() helper, wich covers both vmw_vsock_virtio_transport and vmware_vsock_vmci_transport case. vsock_loopback is the only module that registers a transport for VMADDR_CID_LOCAL (CID 1) and has no hard dependency from any of the vsock transport modules.

Fixes: #41100
Follow-up for 381c78db491a7c5fad8697543dd36ebe9b848718

(cherry picked from commit 7c1075fb8ff2d3b87fa463d542e2e00ac086cbd3)

[vlefebvre: fixes bsc#1259145]